### PR TITLE
Fixed android app crashing on unsuccessful removal 

### DIFF
--- a/android/src/main/kotlin/com/example/local_rembg/LocalRembgPlugin.kt
+++ b/android/src/main/kotlin/com/example/local_rembg/LocalRembgPlugin.kt
@@ -96,13 +96,10 @@ class LocalRembgPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     )
                 }
                 .addOnFailureListener { exception ->
-                    sendErrorResult(result, 0, exception.message)
-                }
-                .addOnFailureListener { exception ->
-                    sendErrorResult(result, 0, exception.message)
+                    returnOriginalImage(result, bitmap)
                 }
         } catch (e: Exception) {
-            sendErrorResult(result, 0, e.message)
+            returnOriginalImage(result, null)
         }
     }
 
@@ -124,6 +121,11 @@ class LocalRembgPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             } else {
                 makeBackgroundTransparent(newBmp, bgConf)
                 resultBmp = newBmp
+            }
+
+            if (isImageBlank(resultBmp)) {
+                returnOriginalImage(result, bitmap)
+                return@launch
             }
 
             val targetWidth = 1080
@@ -177,10 +179,10 @@ class LocalRembgPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
             }
         }
-        if (minX < maxX && minY < maxY) {
-            return Bitmap.createBitmap(bitmap, minX, minY, maxX - minX + 1, maxY - minY + 1)
+        return if (minX < maxX && minY < maxY) {
+            Bitmap.createBitmap(bitmap, minX, minY, maxX - minX + 1, maxY - minY + 1)
         } else {
-            return bitmap
+            bitmap
         }
     }
 
@@ -194,6 +196,28 @@ class LocalRembgPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
             }
         }
+    }
+
+    private fun returnOriginalImage(result: MethodChannel.Result, bitmap: Bitmap?) {
+        val outputStream = ByteArrayOutputStream()
+        bitmap?.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+        val originalImageBytes = outputStream.toByteArray()
+
+        val response = mapOf(
+            "status" to 0,
+            "imageBytes" to originalImageBytes.toList(),
+            "message" to "Returning original image"
+        )
+        result.success(response)
+    }
+
+    private fun isImageBlank(bitmap: Bitmap?): Boolean {
+        if (bitmap == null) return true
+        val width = bitmap.width
+        val height = bitmap.height
+        val pixels = IntArray(width * height)
+        bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+        return pixels.all { it == Color.TRANSPARENT }
     }
 
     private fun sendErrorResult(result: MethodChannel.Result, status: Int, errorMessage: String?) {

--- a/android/src/main/kotlin/com/example/local_rembg/LocalRembgPlugin.kt
+++ b/android/src/main/kotlin/com/example/local_rembg/LocalRembgPlugin.kt
@@ -177,7 +177,11 @@ class LocalRembgPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
             }
         }
-        return Bitmap.createBitmap(bitmap, minX, minY, maxX - minX + 1, maxY - minY + 1)
+        if (minX < maxX && minY < maxY) {
+            return Bitmap.createBitmap(bitmap, minX, minY, maxX - minX + 1, maxY - minY + 1)
+        } else {
+            return bitmap
+        }
     }
 
     private fun makeBackgroundTransparent(bitmap: Bitmap, bgConf: FloatArray) {

--- a/android/src/main/kotlin/com/example/local_rembg/LocalRembgPlugin.kt
+++ b/android/src/main/kotlin/com/example/local_rembg/LocalRembgPlugin.kt
@@ -206,7 +206,7 @@ class LocalRembgPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         val response = mapOf(
             "status" to 0,
             "imageBytes" to originalImageBytes.toList(),
-            "message" to "Returning original image"
+            "message" to "Unable to remove the background"
         )
         result.success(response)
     }


### PR DESCRIPTION
Added checks to ensure that the app does not crash on Android when the removal of background is unsuccessful. Returned the original image in this case with a sensible message